### PR TITLE
added support for expression and assert

### DIFF
--- a/lookml/lib/language_data/_allowed_children.py
+++ b/lookml/lib/language_data/_allowed_children.py
@@ -455,5 +455,8 @@ _allowed_children = \
         "localization_settings": [
                 "default_locale",
                 "localization_level"
+        ],
+        "assert": [
+                "expression"
         ]
 }

--- a/lookml/lib/language_data/config.py
+++ b/lookml/lib/language_data/config.py
@@ -5061,6 +5061,17 @@ config = \
                         "allowed_values": ""
                 }
         },
+        "expression": {
+                "assert": {
+                        "type": "sql",
+                        "subtype": "sql-block ",
+                        "indent": 1,
+                        "default_value": "",
+                        "docs_url": "https://cloud.google.com/looker/docs/reference/param-model-test#assert",
+                        "has_allowed_values": False,
+                        "allowed_values": ""
+                }
+        },
         "max_cache_age": {
                 "datagroup": {
                         "type": "string",


### PR DESCRIPTION
This Pull Request provides a fix for the following issue:

Right now, the initialization of the Looker Project fails:
`proj = lookml.Project(path=project_path, )`

This is because I have the following test:
```
test: airport_traffic_2020_aggregates {
  explore_source: airport_traffic {
      column: count {}
      filters: {
        field: airport_traffic.date_year
        value: "2020"
      }
  }
  assert: assert_count {
    expression: ${airport_traffic.count} = 8052 ;;
  }
}
```

This pull requests adds the support for the `assert` and `expression` keywords.